### PR TITLE
mention bundler gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ This is a ruby gem to interact with Vuforia web services api. Work is in progres
 
 Clone this repo onto your hard drive
 
-Build the gem by issuing:
+Install bundler gem by issuing:
+
+    gem install bundler
+
+Build the gem by:
 
     rake build
 


### PR DESCRIPTION
( I'm new to Ruby. )

I had a quite bare ruby 2.0.0 installed by rvm.

In order to get "rake build" working, I had to install "bundler" gem. I guess it is good to mention it in  README.md
